### PR TITLE
Set parent_issue to title, when update parent_issue (#117)

### DIFF
--- a/lib/redmine_slack/listener.rb
+++ b/lib/redmine_slack/listener.rb
@@ -220,7 +220,11 @@ private
 			title = I18n.t :label_attachment
 		else
 			key = detail.prop_key.to_s.sub("_id", "")
-			title = I18n.t "field_#{key}"
+			if key == "parent"
+				title = I18n.t "field_#{key}_issue"
+			else
+				title = I18n.t "field_#{key}"
+			end
 		end
 
 		short = true


### PR DESCRIPTION
Show parent_project as parent_issue, when update parent_issue. Link is correct, but label is incorrect.

Fixes #116